### PR TITLE
minor: adds version to the manifest file

### DIFF
--- a/generators/app/templates/manifest.json
+++ b/generators/app/templates/manifest.json
@@ -1,3 +1,4 @@
 {
-  "name": "<%= pluginName %>"
+  "name": "<%= pluginName %>",
+  "version": "1.0.0"
 }

--- a/generators/app/templates/manifest.json
+++ b/generators/app/templates/manifest.json
@@ -1,4 +1,4 @@
 {
   "name": "<%= pluginName %>",
-  "version": "1.0.0"
+  "version": "0.1.0"
 }


### PR DESCRIPTION
I decided not to make the version configurable, because this is a starting point, so it should be an initial version. I personally prefer on setting a start on version "1.0.0", but if there are strong feelings for "0.0.1" instead, I can change it.