### PR TITLE
Configures global reloading of plugins

### DIFF
--- a/generators/app/templates/README.md
+++ b/generators/app/templates/README.md
@@ -26,13 +26,19 @@ plugin.
 
 #### Automatically reloading plugins
 
-Optionally you may set `env.port` to force rebuilds to trigger automatic plugin
-reloading. Note that _all_ plugins are reloaded at once for a given InVision
-Studio editor window. The port value can be found in the Developer Dashboard.
+In addition to rebuilding and reinstalling the plugin, the development mode will also automatically reload plugins
+in Studio itself. Note that _all_ plugins are reloaded at once for a given InVision
+Studio editor window.
+
+To setup automatic reloading of plugins, you need to define the `STUDIO_DEV_SERVER_PORT` environment variable with an
+available port number. This will start Studio's development server (which enables plugin reloading), whenever Studio is running.
+Add the following line on your `~/.bash_profile` or other initialization script (to use 9101 as port number):
 
 ```
-npm run start -- --env.port=<your developer dashboard port>
+export STUDIO_DEV_SERVER_PORT=9101
 ```
+
+Studio will need to be restarted to pick up the environment variable.
 
 ### Production Mode
 

--- a/generators/app/templates/webpack.config.js
+++ b/generators/app/templates/webpack.config.js
@@ -41,25 +41,28 @@ const symlinkToStudio = () => {
   }
 };
 
-const reloadStudioPlugins = (env) => {
-  const dashboardPort = env ? env.port : undefined;
+const reloadStudioPlugins = () => {
+  const dashboardPort = process.env.STUDIO_DEV_SERVER_PORT;
+
   if (!dashboardPort) {
     reportError(
-      '`port` environment variable is not set.  Skipping plugin reload. ' +
+      '`STUDIO_DEV_SERVER_PORT` environment variable is not set. Skipping plugin reload. ' +
       'Reload plugins manually from the Apps menu in InVision Studio to see changes.\n'
     );
     return;
   }
   // eslint-disable-next-line no-console
   console.log(chalk.blue(`\n[Dashboard Server] reloading plugins...\n`));
-  fetch(`http://localhost:${dashboardPort}/reload-plugins`)
+  fetch(`http://localhost:${dashboardPort}/reload`)
     .then(res => {
       if (!res.ok) {
         reportError(res.text());
       }
     })
     .catch(err => {
-      if (err.code !== 'ECONNRESET') {
+      if (err.code === 'ECONNREFUSED') {
+        reportError('Could not reload Studio: make sure STUDIO_DEV_SERVER_PORT is set and restart Studio.');
+      } else if (err.code !== 'ECONNRESET') {
         reportError(err.message);
       }
     });


### PR DESCRIPTION
Uses the globally set `STUDIO_DEV_SERVER_PORT` environment variable to do the plugin reloading. This allows every Editor plugin host to reload, and the developer only needs to set the port number once. 