### PR TITLE
Shows up in app dock by default

### DIFF
--- a/generators/app/templates/manifest.json
+++ b/generators/app/templates/manifest.json
@@ -9,5 +9,6 @@
   "author": {
     "name": "<%= name %>",
     "email": "<%= email %>"
-  }
+  },
+  "dockIcon": "default"
 }


### PR DESCRIPTION
Adds:
```
"dockIcon": "default"
```
to display Icon on AppDock.