### PR TITLE
Fixes the regeneratorRuntime error that started happening

### DIFF
--- a/generators/app/templates/.babelrc
+++ b/generators/app/templates/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    "env",
+    ["env", { "targets": { "node": "8"} }],
     "stage-0",
     "react"
   ],


### PR DESCRIPTION
The error happens because we no longer load the regeneratorRuntime, which is not needed either way since the environment supports Node 8+